### PR TITLE
fix: preserve files shared by download tasks

### DIFF
--- a/src/components/task/TaskActions.vue
+++ b/src/components/task/TaskActions.vue
@@ -205,7 +205,7 @@ function onDeleteAll() {
       let fileDeletionFailed = false
       for (const task of tasksToDelete) {
         try {
-          await deleteTaskFiles(task, preferenceStore.config.fileDeletionMode)
+          await deleteTaskFiles(task, preferenceStore.config.fileDeletionMode, taskStore.taskList)
         } catch (error) {
           fileDeletionFailed = true
           logger.warn('TaskActions.onDeleteAllFiles', getErrorMessage(error))
@@ -389,7 +389,7 @@ function purgeRecord() {
       let fileDeletionFailed = false
       for (const task of tasksToClean) {
         try {
-          await deleteTaskFiles(task, preferenceStore.config.fileDeletionMode)
+          await deleteTaskFiles(task, preferenceStore.config.fileDeletionMode, taskStore.taskList)
         } catch (error) {
           fileDeletionFailed = true
           logger.warn('TaskActions.purgeRecordFiles', getErrorMessage(error))

--- a/src/composables/__tests__/useFileDelete.test.ts
+++ b/src/composables/__tests__/useFileDelete.test.ts
@@ -38,6 +38,10 @@ function makeTask(overrides: Partial<Aria2Task> = {}): Aria2Task {
   }
 }
 
+function makeFile(path: string, index = '1') {
+  return { index, path, length: '1000', completedLength: '1000', selected: 'true', uris: [] }
+}
+
 describe('deletePath', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -176,6 +180,49 @@ describe('deleteTaskFiles', () => {
 
     await expect(deleteTaskFiles(task, 'trash')).resolves.toBeUndefined()
     expect(mockDeletePath).not.toHaveBeenCalled()
+  })
+
+  it('keeps a file another task is still downloading', async () => {
+    const removed = makeTask({ gid: 'removed', files: [makeFile('/downloads/shared.bin')] })
+    const kept = makeTask({ gid: 'kept', files: [makeFile('/downloads/shared.bin')] })
+    mockResolveOpenTarget.mockImplementation((task: Aria2Task) => Promise.resolve(task.files?.[0]?.path ?? task.dir))
+
+    await deleteTaskFiles(removed, 'trash', [kept])
+
+    expect(mockDeletePath).not.toHaveBeenCalledWith({ path: '/downloads/shared.bin', mode: 'trash' })
+    expect(mockDeletePath).not.toHaveBeenCalledWith({ path: '/downloads/shared.bin.aria2', mode: 'permanent' })
+  })
+
+  it('keeps a folder that contains files of another task', async () => {
+    const removed = makeTask({ gid: 'removed', files: [makeFile('/downloads/Album/track1.mp3')] })
+    const kept = makeTask({ gid: 'kept', files: [makeFile('/downloads/Album/track2.mp3')] })
+    mockResolveOpenTarget.mockImplementation((task: Aria2Task) =>
+      Promise.resolve(task.gid === 'removed' ? '/downloads/Album' : '/downloads/Album/track2.mp3'),
+    )
+
+    await deleteTaskFiles(removed, 'trash', [kept])
+
+    expect(mockDeletePath).not.toHaveBeenCalledWith({ path: '/downloads/Album', mode: 'trash' })
+  })
+
+  it('still deletes when the other tasks point elsewhere', async () => {
+    const removed = makeTask({ gid: 'removed', files: [makeFile('/downloads/mine.bin')] })
+    const other = makeTask({ gid: 'other', files: [makeFile('/downloads/theirs.bin')] })
+    mockResolveOpenTarget.mockImplementation((task: Aria2Task) => Promise.resolve(task.files?.[0]?.path ?? task.dir))
+
+    await deleteTaskFiles(removed, 'trash', [other])
+
+    expect(mockDeletePath).toHaveBeenCalledWith({ path: '/downloads/mine.bin', mode: 'trash' })
+    expect(mockDeletePath).not.toHaveBeenCalledWith({ path: '/downloads/theirs.bin', mode: 'trash' })
+  })
+
+  it('ignores a stale entry for the task being removed', async () => {
+    const removed = makeTask({ gid: 'removed', files: [makeFile('/downloads/mine.bin')] })
+    mockResolveOpenTarget.mockResolvedValue('/downloads/mine.bin')
+
+    await deleteTaskFiles(removed, 'trash', [removed])
+
+    expect(mockDeletePath).toHaveBeenCalledWith({ path: '/downloads/mine.bin', mode: 'trash' })
   })
 })
 

--- a/src/composables/useFileDelete.ts
+++ b/src/composables/useFileDelete.ts
@@ -24,32 +24,87 @@ async function deletePaths(paths: string[], mode: FileDeletionMode): Promise<voi
   }
 }
 
-export async function cleanupAria2ControlFiles(task: Aria2Task): Promise<void> {
+/** Content paths a task owns: its resolved target, or its individual files. */
+async function resolveContentPaths(task: Aria2Task): Promise<string[]> {
+  const target = await resolveOpenTarget(task)
+  if (target && target !== task.dir) return [target]
+  return (task.files || []).map((file) => file.path)
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+/** True when `path` is, contains, or is contained by one of `protectedPaths`. */
+function isProtected(path: string, protectedPaths: string[]): boolean {
+  if (!path) return false
+  const candidate = normalizePath(path)
+  return protectedPaths.some((protectedPath) => {
+    const other = normalizePath(protectedPath)
+    return candidate === other || candidate.startsWith(`${other}/`) || other.startsWith(`${candidate}/`)
+  })
+}
+
+/**
+ * Content paths still owned by tasks other than `gid`. Tasks pointing at the
+ * same file (e.g. the same URL queued twice, or a re-added torrent) must keep
+ * their data when one of them is removed.
+ */
+async function collectProtectedPaths(gid: string, tasks: Aria2Task[]): Promise<string[]> {
+  const paths = new Set<string>()
+
+  for (const task of tasks) {
+    if (task.gid === gid) continue
+
+    try {
+      for (const path of await resolveContentPaths(task)) {
+        if (path) paths.add(path)
+      }
+    } catch (error) {
+      logger.debug('collectProtectedPaths', `resolve gid=${task.gid} skipped: ${error}`)
+    }
+
+    for (const file of task.files || []) {
+      if (file.path) paths.add(file.path)
+    }
+  }
+
+  return [...paths]
+}
+
+export async function cleanupAria2ControlFiles(task: Aria2Task, protectedPaths: string[] = []): Promise<void> {
   try {
     const paths: string[] = []
     if (task.dir && task.infoHash) {
       paths.push(`${task.dir}/${task.infoHash}.aria2`)
     }
 
-    const target = await resolveOpenTarget(task)
-
-    if (!target || target === task.dir) {
-      for (const f of task.files || []) {
-        if (f.path) paths.push(f.path + '.aria2')
-      }
-    } else {
-      paths.push(target + '.aria2')
+    for (const path of await resolveContentPaths(task)) {
+      if (path) paths.push(path + '.aria2')
     }
 
-    await deletePaths(paths, 'permanent')
+    // A control file belongs to whichever task is still downloading that path;
+    // removing it would reset the surviving task's progress.
+    await deletePaths(
+      paths.filter((path) => !isProtected(path.replace(/\.aria2$/, ''), protectedPaths)),
+      'permanent',
+    )
   } catch (error) {
     logger.debug('cleanupAria2ControlFiles', `cleanup failed: ${error}`)
   }
 }
 
-export async function deleteTaskFiles(task: Aria2Task, mode: FileDeletionMode): Promise<void> {
-  const target = await resolveOpenTarget(task)
-  const contentPaths = target && target !== task.dir ? [target] : (task.files || []).map((file) => file.path)
+export async function deleteTaskFiles(
+  task: Aria2Task,
+  mode: FileDeletionMode,
+  protectedTasks: Aria2Task[] = [],
+): Promise<void> {
+  const protectedPaths = await collectProtectedPaths(task.gid, protectedTasks)
+  const contentPaths = (await resolveContentPaths(task)).filter((path) => {
+    if (!isProtected(path, protectedPaths)) return true
+    logger.warn('deleteTaskFiles', `Skipped ${path}: still referenced by another task`)
+    return false
+  })
   let deletionError: unknown
 
   try {
@@ -57,7 +112,7 @@ export async function deleteTaskFiles(task: Aria2Task, mode: FileDeletionMode): 
   } catch (error) {
     deletionError = error
   } finally {
-    await cleanupAria2ControlFiles(task)
+    await cleanupAria2ControlFiles(task, protectedPaths)
     if (task.dir && task.infoHash) {
       await cleanupAria2MetadataFiles(task.dir, task.infoHash)
     }

--- a/src/composables/useTaskActions.ts
+++ b/src/composables/useTaskActions.ts
@@ -99,7 +99,7 @@ export function useTaskActions(deps: TaskActionsDeps) {
         .then(async () => {
           if (alsoDeleteFiles) {
             try {
-              await deleteTaskFiles(task, config.fileDeletionMode)
+              await deleteTaskFiles(task, config.fileDeletionMode, taskStore.taskList)
             } catch (error) {
               logger.error('TaskView.deleteTaskFiles', error)
               message.error(t('task.remove-task-file-fail'))
@@ -142,7 +142,7 @@ export function useTaskActions(deps: TaskActionsDeps) {
           await taskStore.removeTask(task)
           if (deleteFiles.value) {
             try {
-              await deleteTaskFiles(task, config.fileDeletionMode)
+              await deleteTaskFiles(task, config.fileDeletionMode, taskStore.taskList)
             } catch (error) {
               logger.error('TaskView.deleteTaskFiles', error)
               message.error(t('task.remove-task-file-fail'))
@@ -169,7 +169,7 @@ export function useTaskActions(deps: TaskActionsDeps) {
         .then(async () => {
           if (alsoDeleteFiles) {
             try {
-              await deleteTaskFiles(taskRef, config.fileDeletionMode)
+              await deleteTaskFiles(taskRef, config.fileDeletionMode, taskStore.taskList)
             } catch (error) {
               logger.error('TaskView.deleteRecordFiles', error)
               message.error(t('task.remove-task-file-fail'))
@@ -212,7 +212,7 @@ export function useTaskActions(deps: TaskActionsDeps) {
         try {
           if (deleteFiles.value) {
             try {
-              await deleteTaskFiles(task, config.fileDeletionMode)
+              await deleteTaskFiles(task, config.fileDeletionMode, taskStore.taskList)
             } catch (error) {
               logger.error('TaskView.deleteRecordFiles', error)
               message.error(t('task.remove-task-file-fail'))

--- a/src/stores/__tests__/taskOperations.test.ts
+++ b/src/stores/__tests__/taskOperations.test.ts
@@ -228,7 +228,7 @@ describe('cancelMagnetSelectionDownload', () => {
     expect(api.removeTaskRecord).toHaveBeenNthCalledWith(2, { gid: 'child-gid' })
     expect(api.removeTaskRecord).toHaveBeenNthCalledWith(3, { gid: 'metadata-gid' })
     expect(mockCleanupAria2ControlFiles).toHaveBeenCalledWith(childTask)
-    expect(mockDeleteTaskFiles).toHaveBeenCalledWith(childTask, 'trash')
+    expect(mockDeleteTaskFiles).toHaveBeenCalledWith(childTask, 'trash', expect.any(Array))
     expect(mockCleanupAria2MetadataFiles).toHaveBeenCalledWith('/downloads', 'abcdef1234567890abcdef1234567890abcdef12')
     expect(mockRemoveRecord).toHaveBeenCalledWith('child-gid')
     expect(mockRemoveRecord).toHaveBeenCalledWith('metadata-gid')

--- a/src/stores/task/operations.ts
+++ b/src/stores/task/operations.ts
@@ -150,7 +150,7 @@ export function createTaskOperations(deps: TaskOperationsDeps) {
     }
 
     try {
-      await deleteTaskFiles(task, 'trash')
+      await deleteTaskFiles(task, 'trash', taskList.value)
     } catch (e) {
       logger.debug('TaskOps.cancelMagnetSelection', `deleteTaskFiles gid=${task.gid} skipped: ${e}`)
     }


### PR DESCRIPTION
## Problem
Deleting an errored or stopped task with the file cleanup option could trash a file that is still referenced by another task. This happens when a failed download and a later successful download resolve to the same destination path.

## Solution
I added a shared-path guard to `deleteTaskFiles`. Before deleting user content, the cleanup flow now collects paths referenced by the remaining tasks and skips any exact, parent, or child path conflict. The matching `.aria2` control file is skipped along with it, so the surviving task keeps its resume state instead of restarting from zero. I also pass the current task list through the single-task, batch, purge, and magnet-cancel cleanup flows so they all use the same protection.

Rebased onto `main` after the `FileDeletionMode` refactor: the guard is now an optional third argument to `deleteTaskFiles`, so existing two-argument call sites are unaffected.

## Testing
- `corepack pnpm exec vitest run src/composables/__tests__/useFileDelete.test.ts src/stores/__tests__/taskOperations.test.ts src/components/task/__tests__/TaskActions.test.ts src/views/__tests__/TaskView.test.ts`
- `corepack pnpm lint`
- `corepack pnpm exec vue-tsc --noEmit`

I also ran `corepack pnpm test`: 2121 tests pass. The one failure, `src/stores/__tests__/task.test.ts > addMagnetUri forces integrity checking`, times out on `main` without this change as well.

Fixes #370
