### PR TITLE
fix(download): resolve real filename from Content-Disposition header

### DIFF
--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -2,6 +2,8 @@
 ///
 /// `resolve_filename` — Resolves trustworthy filenames for extensionless HTTP
 /// URLs before forwarding them to aria2.
+/// It also handles opaque CDN-style path filenames when response headers
+/// expose a better name.
 ///
 /// The command deliberately avoids deriving a filename from URL placeholders
 /// such as `/attachment/u/0/`. Stable URL basenames from media/CDN paths may be
@@ -26,14 +28,15 @@ pub(crate) const UNRESOLVED_FILENAME: &str = "unresolved-filename";
 // ── Filename resolution ─────────────────────────────────────────────────
 
 /// Sends a HEAD request to `url` and infers the correct filename (with
-/// extension) when the URL path segment has none.
+/// extension) from HTTP response metadata.
 ///
 /// Returns `Ok(Some("filename.ext"))` on successful resolution, `Ok(None)`
-/// when the URL already has an extension, or `Ok(Some("unresolved-filename"))`
-/// when the server exposes no trustworthy filename.
+/// when a URL with an existing extension has no better response filename, or
+/// `Ok(Some("unresolved-filename"))` when an extensionless URL exposes no
+/// trustworthy filename.
 ///
-/// The frontend calls this for each extensionless URL before `aria2.addUri`,
-/// setting the returned name as the aria2 `out` option.
+/// The frontend calls this for extensionless URLs and opaque CDN-style
+/// basenames before `aria2.addUri`, setting the returned name as aria2 `out`.
 #[tauri::command]
 pub async fn resolve_filename(
     url: String,
@@ -43,11 +46,15 @@ pub async fn resolve_filename(
 ) -> Result<Option<String>, AppError> {
     // 1. Extract basename from the URL path
     let basename = extract_basename(&url);
-    if basename.is_empty() || has_extension(&basename) {
-        return Ok(None); // aria2 can handle this natively
-    }
+    let basename_has_extension = has_extension(&basename);
 
-    log::debug!("resolve_filename: basename={basename:?} has no extension, sending HEAD");
+    if basename.is_empty() {
+        log::debug!("resolve_filename: no URL basename, sending HEAD");
+    } else if basename_has_extension {
+        log::debug!("resolve_filename: basename={basename:?} has extension, probing headers");
+    } else {
+        log::debug!("resolve_filename: basename={basename:?} has no extension, sending HEAD");
+    }
 
     // 2. HEAD request (follows redirects, respects user proxy settings)
     let builder = reqwest::Client::builder()
@@ -76,7 +83,7 @@ pub async fn resolve_filename(
 
     // 3b. Level 2 — Redirect target URL path extension
     let final_basename = extract_basename(resp.url().as_str());
-    if has_extension(&final_basename) {
+    if !basename.is_empty() && !basename_has_extension && has_extension(&final_basename) {
         if let Some(ext) = final_basename.rsplit('.').next() {
             let resolved = format!("{basename}.{ext}");
             log::debug!("resolve_filename: resolved via redirect URL → {resolved}");
@@ -96,6 +103,11 @@ pub async fn resolve_filename(
     }
 
     // 3d. Level 4 — Content-Type MIME → URL basename plus extension, or neutral fallback.
+    if basename_has_extension || basename.is_empty() {
+        log::debug!("resolve_filename: no better response filename; using aria2 native name");
+        return Ok(None);
+    }
+
     if let Some(ct) = resp.headers().get(reqwest::header::CONTENT_TYPE) {
         let mime_str = ct.to_str().unwrap_or("");
         // Strip parameters: "image/jpeg; charset=utf-8" → "image/jpeg"

--- a/src/composables/useAddTaskSubmit.ts
+++ b/src/composables/useAddTaskSubmit.ts
@@ -21,8 +21,8 @@ import {
   normalizeUriLines,
   extractDecodedFilename,
   extractMagnetDisplayName,
-  hasExtension,
   sanitizeAria2OutHint,
+  shouldProbeRemoteFilename,
 } from '@shared/utils/batchHelpers'
 import { buildOuts } from '@shared/utils/rename'
 import { invoke } from '@tauri-apps/api/core'
@@ -261,8 +261,9 @@ export async function submitManualUris(
       // aria2's native filename resolution only uses Content-Disposition
       // and URL path.  CDNs like Twitter/X serve media from extensionless
       // paths (e.g. /media/HCo_0zsbkAEov7s?format=jpg).  For each URL
-      // whose path lacks an extension, invoke the Rust-side HEAD request
-      // to infer the correct name via Content-Type MIME mapping.
+      // whose path lacks an extension or like CDN-style, invoke the
+      // Rust-side HEAD request to infer the correct name via
+      // Content-Type MIME mapping.
       const outs = await Promise.all(
         regularUris.map(async (uri) => {
           // Extension already provided a filename via options.out — skip HEAD.
@@ -270,8 +271,7 @@ export async function submitManualUris(
           // the CDN's Content-Type (e.g. .xml), and aria2.ts addUri() L108
           // overwrites options.out with the outs[] entry.
           if (options.out) return ''
-          const pathFilename = extractDecodedFilename(uri)
-          if (!pathFilename || hasExtension(pathFilename)) return ''
+          if (!shouldProbeRemoteFilename(uri)) return ''
           try {
             const uriContext = form.uriRequestContexts?.[uri]
             const sanitizedHeaders = sanitizeHttpHeaderOptions({

--- a/src/shared/utils/batchHelpers.ts
+++ b/src/shared/utils/batchHelpers.ts
@@ -290,14 +290,25 @@ function looksLikeOpaqueRemoteFilename(filename: string): boolean {
   return /^[A-Za-z0-9]{16,}$/.test(stem) && /[A-Za-z]/.test(stem) && /\d/.test(stem)
 }
 
+const SERVER_ENDPOINT_EXTENSIONS = new Set(['php', 'asp', 'aspx', 'jsp', 'jspx', 'cfm', 'cgi', 'do', 'action'])
+
+function extractExtension(filename: string): string {
+  const match = /\.([a-zA-Z0-9]{1,10})$/.exec(filename)
+  return match ? match[1].toLowerCase() : ''
+}
+
+function looksLikeServerEndpointFilename(filename: string): boolean {
+  return SERVER_ENDPOINT_EXTENSIONS.has(extractExtension(filename))
+}
+
 /**
  * Returns whether manual URL submission should ask the backend to probe HTTP
  * headers for a better filename before handing the task to aria2.
  *
- * We always probe URLs whose path has no usable extension. For URLs that do
- * have an extension, we only probe opaque CDN-style basenames such as
- * "080545q06zvvvvag3u3vh6.zip"; ordinary names like "ubuntu.iso" are left to
- * aria2 to avoid slowing down common manual adds.
+ * We probe when the URL path does not provide a trustworthy filename: no
+ * extension or an opaque CDN-style basename such as "080545q06zvvvvag3u3vh6.zip".
+ * Ordinary names like "ubuntu.iso" are left to aria2 to avoid slowing down common
+ * manual adds.
  */
 export function shouldProbeRemoteFilename(uri: string): boolean {
   if (!hasHttpDownloadScheme(uri)) return false
@@ -305,6 +316,7 @@ export function shouldProbeRemoteFilename(uri: string): boolean {
   const filename = extractDecodedFilename(uri)
   if (!filename) return false
   if (!hasExtension(filename)) return true
+  if (looksLikeServerEndpointFilename(filename)) return true
   return looksLikeOpaqueRemoteFilename(filename)
 }
 

--- a/src/shared/utils/batchHelpers.ts
+++ b/src/shared/utils/batchHelpers.ts
@@ -272,6 +272,42 @@ export function hasExtension(filename: string): boolean {
   return /\.[a-zA-Z0-9]{1,10}$/.test(filename)
 }
 
+function hasHttpDownloadScheme(uri: string): boolean {
+  try {
+    const protocol = new URL(uri).protocol.toLowerCase()
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return /^https?:\/\//i.test(uri)
+  }
+}
+
+function looksLikeOpaqueRemoteFilename(filename: string): boolean {
+  const dot = filename.lastIndexOf('.')
+  const stem = dot > 0 ? filename.slice(0, dot) : filename
+  if (stem.length < 16) return false
+  if (/^\d{12,}$/.test(stem)) return true
+  if (/^[a-fA-F0-9]{16,}$/.test(stem)) return true
+  return /^[A-Za-z0-9]{16,}$/.test(stem) && /[A-Za-z]/.test(stem) && /\d/.test(stem)
+}
+
+/**
+ * Returns whether manual URL submission should ask the backend to probe HTTP
+ * headers for a better filename before handing the task to aria2.
+ *
+ * We always probe URLs whose path has no usable extension. For URLs that do
+ * have an extension, we only probe opaque CDN-style basenames such as
+ * "080545q06zvvvvag3u3vh6.zip"; ordinary names like "ubuntu.iso" are left to
+ * aria2 to avoid slowing down common manual adds.
+ */
+export function shouldProbeRemoteFilename(uri: string): boolean {
+  if (!hasHttpDownloadScheme(uri)) return false
+
+  const filename = extractDecodedFilename(uri)
+  if (!filename) return false
+  if (!hasExtension(filename)) return true
+  return looksLikeOpaqueRemoteFilename(filename)
+}
+
 // ── External filename hint resolution ───────────────────────────────
 
 const GENERIC_EXTERNAL_FILENAME_HINTS = new Set(['download', 'unresolved-filename'])


### PR DESCRIPTION
<!--
Before submitting, read docs/CONTRIBUTING.md — especially the Pull Request section.

PR title MUST follow Conventional Commits format.

  Good titles:
    fix(macos): resolve tray icon blurriness on Retina displays
    feat: add per-task speed limit control
    docs: update i18n translation guide
    refactor: extract tracker sync into composable

  Bad titles:
    fix bugs
    update code
    fix #123
    WIP
-->

## Description

<!-- What does this change do and why? Link related issues: Fixes #123 -->
Close #382 

之前客户端在解析手动添加的下载链接时，主要根据 URL 路径判断文件名：如果 `basename` 已经包含扩展名，就直接使用该文件名；只有在路径没有扩展名时，才会调用 Rust 发起 `HEAD` 请求，并尝试从 `Content-Disposition` 中得到真实文件名。

这种策略的问题是，URL 路径中的 `basename`  不一定是真实的文件名。比如 CDN 派生链接可能类似随机字符串或哈希值；另外一些动态下载入口的路径可能是 `forum.php`、`download.aspx` 这类动态的服务端端点，真实文件名需要通过重定向后的响应头才能获得。这些类似的情况都会跳过响应头探测，最终使用不准确的文件名。

本次提交调整了手动 URL 的文件名解析策略：不再只以“是否存在扩展名”作为是否探测的唯一依据，而是判断 URL 路径中的文件名候选是否可信。当 `basename` 看起来像 CDN 随机名、哈希值，或是服务端动态入口文件名时，即使它已经包含扩展名，也会执行一次短超时响应头检测，优先从 `Content-Disposition` 获取更准确的原始文件名；如果响应头没有提供可靠文件名，则继续回退到原有 URL 文件名解析逻辑。

## Type of change

<!-- Check the one that applies. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

<!-- Describe how you verified your changes. "It compiles" is not sufficient. -->
pnpm test and cargo test

## AI usage disclosure

<!-- Check the one that applies. Honest disclosure is expected — misleading answers will result in PR closure. -->

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

If AI was used, specify the tool: <!-- e.g., GitHub Copilot, Claude, ChatGPT -->

ChatGPT

## Checklist

### Required — PR will not be reviewed without these

- [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
- [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files)
- [x] PR touches **fewer than 10 files**
- [x] PR addresses **one concern only** — no mixed features, config tweaks, or unrelated fixes
- [x] All commands pass locally:
  ```
  pnpm format:check
  npx vue-tsc --noEmit
  pnpm test
  cd src-tauri && cargo test
  ```
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

### If applicable

- [ ] New feature was discussed and approved in an issue before implementation
- [ ] Tests written **before** implementation (TDD: red → green → refactor)
- [ ] i18n keys updated in **all 27 locales** via batch Python script (see AGENTS.md §D)
- [ ] New config key follows the full checklist in AGENTS.md §C
- [ ] Rust changes compile with `cargo clippy` (zero warnings)

## Release notes

<!-- One-line description for end users, or "none" if not user-facing. -->

Notes: 
