### PR TITLE
fix(app): forward CLI download arguments on cold start and support silent mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -439,6 +439,22 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // ── External CLI input URLs on cold start ────────────────────────
+    let argv: Vec<String> = std::env::args().collect();
+    let initial_urls = services::deep_link::filter_external_input_args(&argv);
+    if !initial_urls.is_empty() {
+        let app_handle = app.handle();
+        if services::deep_link::is_silent_arg_launch(&argv) {
+            services::deep_link::route_silent_external_inputs(
+                app_handle,
+                initial_urls,
+                "cold-start",
+            );
+        } else {
+            services::deep_link::route_external_inputs(app_handle, initial_urls, "cold-start");
+        }
+    }
+
     // ── GeoIP: load bundled DB-IP Country Lite for peer country flags ─
     let geoip_state = commands::geoip::init_geoip(&app.handle().clone());
     app.manage(geoip_state);
@@ -645,7 +661,11 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             let urls = services::deep_link::filter_external_input_args(&argv);
             if !urls.is_empty() {
-                services::deep_link::route_external_inputs(app, urls, "single-instance");
+                if services::deep_link::is_silent_arg_launch(&argv) {
+                    services::deep_link::route_silent_external_inputs(app, urls, "single-instance");
+                } else {
+                    services::deep_link::route_external_inputs(app, urls, "single-instance");
+                }
                 return;
             }
 

--- a/src-tauri/src/services/deep_link.rs
+++ b/src-tauri/src/services/deep_link.rs
@@ -74,6 +74,12 @@ pub fn is_autostart_arg_launch(args: &[String]) -> bool {
         .any(|arg| arg == "--autostart" || arg.starts_with("--autostart="))
 }
 
+/// Returns true when argv requests silent download submission without focusing UI.
+pub fn is_silent_arg_launch(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--silent" || arg.starts_with("--silent="))
+}
+
 /// Drain pending external inputs for the frontend boot path.
 pub fn take_pending_deep_links(state: &PendingDeepLinkState) -> PendingDeepLinksPayload {
     match state.0.lock() {
@@ -115,6 +121,10 @@ pub fn mark_frontend_unready(app: &AppHandle) {
 /// destroyed lightweight-mode window.
 pub fn route_external_inputs(app: &AppHandle, urls: Vec<String>, source: &'static str) {
     route_external_inputs_with_intent(app, urls, source, false);
+}
+
+pub fn route_silent_external_inputs(app: &AppHandle, urls: Vec<String>, source: &'static str) {
+    route_external_inputs_with_intent(app, urls, source, true);
 }
 
 fn route_external_inputs_with_intent(
@@ -238,7 +248,7 @@ fn wake_main_window(app: &AppHandle, source: &'static str, silent: bool) {
 mod tests {
     use super::{
         append_unique_pending, filter_external_input_args, is_autostart_arg_launch,
-        take_pending_deep_links, PendingDeepLinkState,
+        is_silent_arg_launch, take_pending_deep_links, PendingDeepLinkState,
     };
 
     #[test]
@@ -277,6 +287,23 @@ mod tests {
         assert!(!is_autostart_arg_launch(&[
             "MotrixNext.exe".to_string(),
             "--flag".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn detects_silent_args_for_cli_launches() {
+        assert!(is_silent_arg_launch(&[
+            "motrix-next".to_string(),
+            "--silent".to_string(),
+            "https://example.com/file.zip".to_string(),
+        ]));
+        assert!(is_silent_arg_launch(&[
+            "motrix-next".to_string(),
+            "--silent=true".to_string(),
+        ]));
+        assert!(!is_silent_arg_launch(&[
+            "motrix-next".to_string(),
+            "https://example.com/file.zip".to_string(),
         ]));
     }
 


### PR DESCRIPTION
## Description

CLI download arguments (such as `motrix-next <url|magnet>` or `open -a MotrixNext --args <url>`) are handled during single-instance launches via `services::deep_link::filter_external_input_args(&argv)`, but were silently dropped during cold start because `setup_app()` did not forward `std::env::args()`.

Additionally, invoking with `--silent` previously fell back to `route_external_inputs()`, which activates and focuses the main window instead of routing with silent intent.

This change:
1. Parses and forwards CLI external inputs during cold start in `setup_app()`, enqueueing them into `PendingDeepLinkState` so the frontend consumes them via `take_pending_deep_links` when ready.
2. Introduces `is_silent_arg_launch()` to check for `--silent` / `--silent=true` flags across both cold-start and single-instance paths.
3. Exports `route_silent_external_inputs()` in `src-tauri/src/services/deep_link.rs` to preserve silent routing intent.
4. Adds unit tests for `is_silent_arg_launch()`.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

- [x] Frontend checks passed: `pnpm format:check`, `npx vue-tsc --noEmit`, `pnpm test`
- [x] Rust checks passed: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test --workspace --all-targets`
- [x] Manual testing completed, or not needed for this change

Unchecked checks:

- None. Both frontend suite (`pnpm test` - 72 suites, 1289 passed) and Rust suite (`cargo test --lib` - 423 passed) executed and passed cleanly.

## AI usage disclosure

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

AI model:

Antigravity (Google DeepMind)

## Checklist

- [x] I kept this PR template complete and understand incomplete PRs may be closed without review
- [x] I have read [CONTRIBUTING.md](https://github.com/AnInsomniacy/motrix-next/blob/main/docs/CONTRIBUTING.md)
- [x] This PR is focused, under the documented size limits, and uses Conventional Commits
- [x] Tests were added or updated for risky logic changes, or this PR explains why tests are not needed

## Release notes

Notes: Ensure CLI download arguments and `--silent` flags are consistently handled on both cold start and single instance.
