### PR TITLE
fix(preference): propagate connection and speed limits to active tasks

### DIFF
--- a/src/composables/__tests__/usePreferenceForm.test.ts
+++ b/src/composables/__tests__/usePreferenceForm.test.ts
@@ -45,11 +45,17 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }))
 
-// ── Mock aria2 API (changeGlobalOption + isEngineReady) ─────────────
+// ── Mock aria2 API ──────────────────────────────────────────────────
 const mockChangeGlobalOption = vi.fn().mockResolvedValue(undefined)
+const mockChangeOption = vi.fn().mockResolvedValue(undefined)
+const mockFetchTaskList = vi.fn().mockResolvedValue([])
+const mockSaveSession = vi.fn().mockResolvedValue('OK')
 const mockIsEngineReady = vi.fn().mockReturnValue(true)
 vi.mock('@/api/aria2', () => ({
   changeGlobalOption: (...args: unknown[]) => mockChangeGlobalOption(...args),
+  changeOption: (...args: unknown[]) => mockChangeOption(...args),
+  fetchTaskList: (...args: unknown[]) => mockFetchTaskList(...args),
+  saveSession: (...args: unknown[]) => mockSaveSession(...args),
   isEngineReady: () => mockIsEngineReady(),
 }))
 
@@ -68,6 +74,7 @@ function extractMessageText(value: unknown): string {
 interface TestForm extends Record<string, unknown> {
   dir: string
   maxConcurrentDownloads: number
+  streamMaxConnections?: number
   locale: string
 }
 
@@ -76,11 +83,13 @@ function makeOptions(overrides: Partial<Parameters<typeof usePreferenceForm<Test
     buildForm: () => ({
       dir: '/downloads',
       maxConcurrentDownloads: 6,
+      streamMaxConnections: 64,
       locale: 'en-US',
     }),
     buildSystemConfig: (f: TestForm) => ({
       dir: f.dir,
       'max-concurrent-downloads': String(f.maxConcurrentDownloads),
+      ...(f.streamMaxConnections !== undefined ? { 'stream-max-connections': String(f.streamMaxConnections) } : {}),
     }),
     ...overrides,
   }
@@ -113,6 +122,7 @@ describe('usePreferenceForm', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockIsEngineReady.mockReturnValue(true)
   })
 
   it('initialises form with buildForm values and isDirty=false', () => {
@@ -445,6 +455,78 @@ describe('usePreferenceForm', () => {
     await handleSave()
 
     expect(mockChangeGlobalOption).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('propagates stream-max-connections changes to active tasks and persists session', async () => {
+    const store = usePreferenceStore()
+    store.updateAndSave = vi.fn().mockResolvedValue(true)
+    mockFetchTaskList.mockResolvedValueOnce([{ gid: 'task-1' }, { gid: 'task-2' }])
+
+    const { result, unmount } = withSetup(() => usePreferenceForm(makeOptions()))
+    const { form, handleSave } = result
+
+    form.value.streamMaxConnections = 16
+    await handleSave()
+
+    expect(mockChangeGlobalOption).toHaveBeenCalledWith(expect.objectContaining({ 'stream-max-connections': '16' }))
+    expect(mockFetchTaskList).toHaveBeenCalledWith({ type: 'active' })
+    expect(mockChangeOption).toHaveBeenCalledTimes(2)
+    expect(mockChangeOption).toHaveBeenCalledWith({
+      gid: 'task-1',
+      options: { 'stream-max-connections': '16' },
+    })
+    expect(mockChangeOption).toHaveBeenCalledWith({
+      gid: 'task-2',
+      options: { 'stream-max-connections': '16' },
+    })
+    expect(mockSaveSession).toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('does not fetch tasks or call changeOption when changed options are not task-propagatable', async () => {
+    const store = usePreferenceStore()
+    store.updateAndSave = vi.fn().mockResolvedValue(true)
+
+    const { result, unmount } = withSetup(() => usePreferenceForm(makeOptions()))
+    const { form, handleSave } = result
+
+    form.value.maxConcurrentDownloads = 8
+    await handleSave()
+
+    expect(mockChangeGlobalOption).toHaveBeenCalledWith({ 'max-concurrent-downloads': '8' })
+    expect(mockFetchTaskList).not.toHaveBeenCalled()
+    expect(mockChangeOption).not.toHaveBeenCalled()
+    expect(mockSaveSession).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('restores task options and session during rollback when save fails', async () => {
+    const store = usePreferenceStore()
+    store.config.streamMaxConnections = 64
+    store.updateAndSave = vi.fn().mockResolvedValue(true)
+    mockFetchTaskList.mockResolvedValue([{ gid: 'task-1' }])
+
+    const { result, unmount } = withSetup(() =>
+      usePreferenceForm(
+        makeOptions({
+          afterSave: () => Promise.reject(new Error('post-save failure')),
+        }),
+      ),
+    )
+
+    result.form.value.streamMaxConnections = 16
+    await expect(result.handleSave()).rejects.toThrow('post-save failure')
+
+    // During rollback, should revert active task options to 64
+    expect(mockChangeOption).toHaveBeenLastCalledWith({
+      gid: 'task-1',
+      options: { 'stream-max-connections': '64' },
+    })
+    expect(mockSaveSession).toHaveBeenCalled()
 
     unmount()
   })

--- a/src/composables/usePreferenceForm.ts
+++ b/src/composables/usePreferenceForm.ts
@@ -12,9 +12,9 @@ import { invoke } from '@tauri-apps/api/core'
 import { usePreferenceStore } from '@/stores/preference'
 import { useAppMessage } from '@/composables/useAppMessage'
 import { filterHotReloadableKeys } from '@shared/utils/config'
-import { changeGlobalOption, isEngineReady } from '@/api/aria2'
+import { changeGlobalOption, changeOption, fetchTaskList, isEngineReady, saveSession } from '@/api/aria2'
 import { logger } from '@shared/logger'
-import type { AppConfig } from '@shared/types'
+import type { AppConfig, Aria2EngineOptions } from '@shared/types'
 import { validateAppConfigCandidate } from '@shared/configConstraints'
 import { buildSystemConfigFromAppConfig } from '@shared/utils/systemConfig'
 
@@ -62,6 +62,31 @@ export interface UsePreferenceFormOptions<T extends Record<string, unknown>> {
    * `preferenceStore.updateAndSave`. Defaults to spreading the form as-is.
    */
   transformForStore?: (form: T) => Partial<AppConfig>
+}
+
+const TASK_PROPAGATABLE_KEYS = ['stream-max-connections', 'max-download-limit', 'max-upload-limit'] as const
+
+async function propagateOptionsToActiveTasks(options: Aria2EngineOptions): Promise<void> {
+  const taskOptionsToPropagate = Object.fromEntries(
+    Object.entries(options).filter(([key]) =>
+      TASK_PROPAGATABLE_KEYS.includes(key as (typeof TASK_PROPAGATABLE_KEYS)[number]),
+    ),
+  ) as Aria2EngineOptions
+
+  if (Object.keys(taskOptionsToPropagate).length === 0) return
+
+  const tasks = await fetchTaskList({ type: 'active' })
+  if (tasks.length > 0) {
+    await Promise.allSettled(
+      tasks.map((task) =>
+        changeOption({
+          gid: task.gid,
+          options: taskOptionsToPropagate,
+        }),
+      ),
+    )
+    await saveSession()
+  }
 }
 
 /**
@@ -143,6 +168,7 @@ export function usePreferenceForm<T extends Record<string, unknown>>(options: Us
       if (shouldHotReload) {
         hotReloadAttempted = true
         await changeGlobalOption(changedHotConfig as Partial<AppConfig>)
+        await propagateOptionsToActiveTasks(changedHotConfig as Aria2EngineOptions)
       }
 
       const saved = await preferenceStore.updateAndSave(storeData)
@@ -183,6 +209,7 @@ export function usePreferenceForm<T extends Record<string, unknown>>(options: Us
       if (hotReloadAttempted && Object.keys(rollbackHotConfig).length > 0) {
         try {
           await changeGlobalOption(rollbackHotConfig as Partial<AppConfig>)
+          await propagateOptionsToActiveTasks(rollbackHotConfig as Aria2EngineOptions)
         } catch (rollbackError) {
           rollbackFailed = true
           logger.error('PreferenceForm.rollback', rollbackError)


### PR DESCRIPTION
### Summary
When modifying download preferences (such as **HTTP Connections per File** / `stream-max-connections` or task speed limits), Motrix previously only dispatched `aria2.changeGlobalOption`.

However, download tasks are created in `useAddTaskSubmit` with explicit task-level options (e.g. `'stream-max-connections': String(form.streamMaxConnections)`). In Aria2, task-level options take precedence over global options, and these options are also serialized into the session file (`download.session`). Consequently, existing active or queued downloads never picked up the updated preference changes and remained permanently locked to their initial connection count.

### Solution
1. In `src/composables/usePreferenceForm.ts`, when saving preferences with hot-reloadable task-propagatable keys (`stream-max-connections`, `max-download-limit`, `max-upload-limit`), query active/waiting tasks and propagate the updated options to each task via `changeOption`, followed by `saveSession()`.
2. Include full rollback support restoring previous task options if subsequent persistence or post-save hooks fail.
3. Added unit tests in `usePreferenceForm.test.ts` verifying live task option propagation and rollback behavior.

### Verification
- `pnpm test` passed (all tests green, including 3 new test cases).
- `pnpm vue-tsc --noEmit` passed with 0 errors.
- `pnpm eslint` & `pnpm prettier --check` passed.